### PR TITLE
Response parsing works

### DIFF
--- a/bin/ncddns
+++ b/bin/ncddns
@@ -33,10 +33,10 @@ main() {
 				output=$(echo url="${target}" | curl -s -K -)
 
 				local errors
-				if error=$(echo "${output}" | xmllint --xpath '//ErrCount/text()' -); then
+				if error=$(echo "${output}" | sed 's/utf-16/utf-8/' | xmllint --xpath '//ErrCount/text()' -); then
 					echo "Successfully updated dynamic DNS to ${ip}"
 				else
-					local errorText=$(echo "${output}" | xmllint --xpath '//ResponseString/text()' -)
+					local errorText=$(echo "${output}" | sed 's/utf-16/utf-8/' | xmllint --xpath '//ResponseString/text()' -)
 					echo "Errors while updating dynamic DNS (${errorText})" >&2
 				fi
 			fi

--- a/bin/ncddns
+++ b/bin/ncddns
@@ -32,11 +32,10 @@ main() {
 				local target="https://dynamicdns.park-your-domain.com/update?host=${host:=@}&domain=${domain}&password=${password}&ip=${ip}"
 				output=$(echo url="${target}" | curl -s -K -)
 
-				local errors
-				if error=$(echo "${output}" | sed 's/utf-16/utf-8/' | xmllint --xpath '//ErrCount/text()' -); then
+				local errorText=$(echo "${output}" | sed 's/utf-16/utf-8/' | xmllint --xpath '//ResponseString/text()' - 2>/dev/null)
+				if [ -z "$errorText" ]; then
 					echo "Successfully updated dynamic DNS to ${ip}"
 				else
-					local errorText=$(echo "${output}" | sed 's/utf-16/utf-8/' | xmllint --xpath '//ResponseString/text()' -)
 					echo "Errors while updating dynamic DNS (${errorText})" >&2
 				fi
 			fi


### PR DESCRIPTION
Parsing xml response from  dynamicdns.park-your-domain.com resulted in error. File was parsed as UTF-16, thought "?" character was interpreted as UTF-8. Just added sed replace command to rewrite encoding in header.

Tested on debian bullseye with libxml2-utils 2.9.10.